### PR TITLE
feat: add ingredients list component and backstage guardiance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,8 @@ const App: FC = () => {
           <h3>狀態： {loginState}</h3>
         )}
         <Link to="/sign_in">Sign In</Link> |{" "}
-        <Link to="/sign_out">Sign Out</Link>
+        <Link to="/sign_out">Sign Out</Link> |{" "}
+        <Link to="/admin">去後台</Link>
       </nav>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { apiCurrentUser } from "./api";
 
 const App: FC = () => {
   const [userName, setUserName] = useState("");
+  const [canEnterBackStage, setCanEnterBackStage] = useState(false);
   const [loginState, setLoginState] = useState("剛進入頁面");
 
   useEffect(() => {
@@ -16,6 +17,7 @@ const App: FC = () => {
       .then((res) => {
         if (!!res.data.user) {
           setUserName(res.data.user.name);
+          setCanEnterBackStage(res.data.user.is_admin);
         }
       })
       .catch((error) => setLoginState(error.message));
@@ -32,7 +34,7 @@ const App: FC = () => {
         )}
         <Link to="/sign_in">Sign In</Link> |{" "}
         <Link to="/sign_out">Sign Out</Link> |{" "}
-        <Link to="/admin">去後台</Link>
+        {canEnterBackStage && (<Link to="/admin">去後台</Link>)}
       </nav>
     </div>
   );

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import {ApiCurrentUser, ApiUserSignIn, ApiUserSignOut, CurrentUserResponse, SignInResponse, SignOutResponse} from "./api.type";
+import {ApiCurrentUser, ApiGetIngredients, ApiUserSignIn, ApiUserSignOut, CurrentUserResponse, IngredientsResponse, SignInResponse, SignOutResponse} from "./api.type";
 
 axios.defaults.withCredentials = true;
 
@@ -25,12 +25,5 @@ export const apiCurrentUser: ApiCurrentUser = async () =>
   await backendRequest.get<CurrentUserResponse>("/current_user");
 
 // ingredients Api
-// interface IngredientsResponse {
-//   status: string;
-//   ingredients: Array<{ name: string; }>;
-// }
-
-// type GetIngredients = () => Promise<AxiosResponse<IngredientsResponse>>;
-
-// export const GetIngredients: GetIngredients = async (data) =>
-//   await backendRequest.get<SignInResponse>("/admin/ingredients", data);
+export const apiGetIngredients: ApiGetIngredients = async () =>
+  await backendRequest.get<IngredientsResponse>("/admin/ingredients");

--- a/src/api.ts
+++ b/src/api.ts
@@ -23,3 +23,14 @@ export const apiUserSignOut: ApiUserSignOut = async () =>
 // currentUser Api
 export const apiCurrentUser: ApiCurrentUser = async () =>
   await backendRequest.get<CurrentUserResponse>("/current_user");
+
+// ingredients Api
+// interface IngredientsResponse {
+//   status: string;
+//   ingredients: Array<{ name: string; }>;
+// }
+
+// type GetIngredients = () => Promise<AxiosResponse<IngredientsResponse>>;
+
+// export const GetIngredients: GetIngredients = async (data) =>
+//   await backendRequest.get<SignInResponse>("/admin/ingredients", data);

--- a/src/api.type.ts
+++ b/src/api.type.ts
@@ -29,7 +29,7 @@ export type ApiUserSignOut = () => Promise<AxiosResponse<SignOutResponse>>;
 export interface CurrentUserResponse {
   status: string;
   message?: string;
-  user?: { name: string };
+  user?: { name: string, is_admin: boolean };
 }
 
 export type ApiCurrentUser = () => Promise<AxiosResponse<CurrentUserResponse>>;

--- a/src/api.type.ts
+++ b/src/api.type.ts
@@ -33,3 +33,11 @@ export interface CurrentUserResponse {
 }
 
 export type ApiCurrentUser = () => Promise<AxiosResponse<CurrentUserResponse>>;
+
+// ingredients
+export interface IngredientsResponse {
+  status: string;
+  ingredients: Array<{ id: string, name: string; }>;
+}
+
+export type ApiGetIngredients = () => Promise<AxiosResponse<IngredientsResponse>>;

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "react";
+import { Link } from "react-router-dom";
 
 import BackStageGuardian from "./Admin/BackStageGuardian";
 
@@ -6,6 +7,7 @@ const Admin: FC = () => {
   return(
     <BackStageGuardian>
       <p>Admin</p>
+      <p><Link to="/admin/ingredients">ingedients list</Link></p>
     </BackStageGuardian>
   )
 }

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -1,0 +1,9 @@
+import type { FC } from "react";
+
+const Admin: FC = () => {
+  return(
+    <p>Admin</p>
+  )
+}
+
+export default Admin;

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -1,8 +1,12 @@
 import type { FC } from "react";
 
+import BackStageGuardian from "./Admin/BackStageGuardian";
+
 const Admin: FC = () => {
   return(
-    <p>Admin</p>
+    <BackStageGuardian>
+      <p>Admin</p>
+    </BackStageGuardian>
   )
 }
 

--- a/src/components/Admin/AdminIngredientsList.tsx
+++ b/src/components/Admin/AdminIngredientsList.tsx
@@ -32,8 +32,8 @@ const AdminIngredientsList: FC = () => {
   return (
     <BackStageGuardian>
       <div>
-        {ingredients.map((ingredient) => {
-          return <li key={ingredient.id}> id: {ingredient.id} name: {ingredient.name}</li>
+        {ingredients.map(({id, name}) => {
+          return <li key={id}> id: {id} name: {name}</li>
         })}
       </div>
     </BackStageGuardian>

--- a/src/components/Admin/AdminIngredientsList.tsx
+++ b/src/components/Admin/AdminIngredientsList.tsx
@@ -1,6 +1,7 @@
 import { type FC,useEffect,useState } from "react";
 
 import { apiGetIngredients } from "../../api";
+import BackStageGuardian from "./BackStageGuardian";
 
 interface Ingredient {
   id: string;
@@ -29,11 +30,13 @@ const AdminIngredientsList: FC = () => {
   }, []);
 
   return (
-    <div>
-      {ingredients.map((ingredient) => {
-        return <li key={ingredient.id}> id: {ingredient.id} name: {ingredient.name}</li>
-      })}
-    </div>
+    <BackStageGuardian>
+      <div>
+        {ingredients.map((ingredient) => {
+          return <li key={ingredient.id}> id: {ingredient.id} name: {ingredient.name}</li>
+        })}
+      </div>
+    </BackStageGuardian>
   );
 }
 

--- a/src/components/Admin/AdminIngredientsList.tsx
+++ b/src/components/Admin/AdminIngredientsList.tsx
@@ -1,0 +1,40 @@
+import { type FC,useEffect,useState } from "react";
+
+import { apiGetIngredients } from "../../api";
+
+interface Ingredient {
+  id: string;
+  name: string;
+}
+
+const AdminIngredientsList: FC = () => {
+  const [ingredients, setIngredients] = useState<Ingredient[]>([]);
+
+  useEffect(() => {
+    apiGetIngredients()
+      .then((res) => {
+        if (!!res.data.ingredients) {
+          setIngredients(
+            res.data.ingredients.map((ingredient) => {
+              return {
+                id: ingredient.id,
+                name: ingredient.name,
+              };
+          }));
+        }
+      })
+      .catch((_error) => {
+        // do nothing
+      });
+  }, []);
+
+  return (
+    <div>
+      {ingredients.map((ingredient) => {
+        return <li key={ingredient.id}> id: {ingredient.id} name: {ingredient.name}</li>
+      })}
+    </div>
+  );
+}
+
+export default AdminIngredientsList;

--- a/src/components/Admin/BackStageGuardian/BackStageGuardian.tsx
+++ b/src/components/Admin/BackStageGuardian/BackStageGuardian.tsx
@@ -1,0 +1,23 @@
+import { FC, Fragment, useEffect, useState } from "react";
+
+import { apiCurrentUser } from "../../../api";
+import NotFound from "../../NotFound";
+import { BackStageGuardianProps } from "./BackStageGuardian.type";
+
+const BackStageGuardian: FC<BackStageGuardianProps> = ({children}) => {
+  const [canEnterBackStage, setCanEnterBackStage] = useState(false);
+
+  useEffect(() => {
+    apiCurrentUser()
+      .then((res) => {
+        if (!!res.data.user) {
+          setCanEnterBackStage(res.data.user.is_admin);
+        }
+      })
+      .catch((_error) => setCanEnterBackStage(false));
+  }, []);
+  if(!canEnterBackStage) return(<NotFound />)
+  return (<>{children}</>)
+}
+
+export default BackStageGuardian;

--- a/src/components/Admin/BackStageGuardian/BackStageGuardian.tsx
+++ b/src/components/Admin/BackStageGuardian/BackStageGuardian.tsx
@@ -1,11 +1,13 @@
 import { FC, Fragment, useEffect, useState } from "react";
 
 import { apiCurrentUser } from "../../../api";
+import Loading from "../../Loading";
 import NotFound from "../../NotFound";
 import { BackStageGuardianProps } from "./BackStageGuardian.type";
 
 const BackStageGuardian: FC<BackStageGuardianProps> = ({children}) => {
   const [canEnterBackStage, setCanEnterBackStage] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     apiCurrentUser()
@@ -14,8 +16,10 @@ const BackStageGuardian: FC<BackStageGuardianProps> = ({children}) => {
           setCanEnterBackStage(res.data.user.is_admin);
         }
       })
-      .catch((_error) => setCanEnterBackStage(false));
+      .catch((_error) => setCanEnterBackStage(false))
+      .finally(() => setIsLoading(false));
   }, []);
+  if(isLoading) return(<Loading />)
   if(!canEnterBackStage) return(<NotFound />)
   return (<>{children}</>)
 }

--- a/src/components/Admin/BackStageGuardian/BackStageGuardian.type.ts
+++ b/src/components/Admin/BackStageGuardian/BackStageGuardian.type.ts
@@ -1,0 +1,5 @@
+import { ReactNode } from "react";
+
+export interface BackStageGuardianProps {
+  children?: ReactNode;
+}

--- a/src/components/Admin/BackStageGuardian/index.ts
+++ b/src/components/Admin/BackStageGuardian/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BackStageGuardian';

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -1,0 +1,25 @@
+.container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.spinner {
+  border: 10px solid rgba(0, 0, 0, 0.1);
+  border-left-color: #09f;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -1,0 +1,13 @@
+import { FC } from "react";
+
+import styles from './Loading.module.css';
+
+const Loading: FC = () => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.spinner}></div>
+    </div>
+  );
+}
+
+export default Loading;

--- a/src/components/Loading/index.ts
+++ b/src/components/Loading/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Loading';

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,0 +1,12 @@
+import { FC } from "react";
+
+const NotFound: FC = () => {
+  return (
+    <div>
+      <h1>404 - Page Not Found</h1>
+      <p>Oops! The page you are looking for does not exist.</p>
+    </div>
+  );
+}
+
+export default NotFound;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import App from "./App";
+import Admin from "./components/Admin";
 import SignIn from "./components/SignIn";
 import SignOut from "./components/SignOut";
 import reportWebVitals from "./reportWebVitals";
@@ -19,6 +20,7 @@ root.render(
         <Route path="/" element={<App />} />
         <Route path="sign_in" element={<SignIn />} />
         <Route path="sign_out" element={<SignOut />} />
+        <Route path="admin" element={<Admin />} />
       </Routes>
     </BrowserRouter>
   </React.StrictMode>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import App from "./App";
 import Admin from "./components/Admin";
+import AdminIngredientsList from "./components/Admin/AdminIngredientsList";
 import SignIn from "./components/SignIn";
 import SignOut from "./components/SignOut";
 import reportWebVitals from "./reportWebVitals";
@@ -21,6 +22,7 @@ root.render(
         <Route path="sign_in" element={<SignIn />} />
         <Route path="sign_out" element={<SignOut />} />
         <Route path="admin" element={<Admin />} />
+        <Route path="admin/ingredients" element={<AdminIngredientsList />} />
       </Routes>
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Purpose of This Pull Request
1. add ingredients list component for back stage
2. add BackstageGuardience component to prevent backstages pages from visiting by normal user

But  the BackstageGuadience would always flash with NotFound component view then with the correct view page, is there any suggested way to prevent this?

https://github.com/qoosuperman/taverneer-frontend/assets/50241297/17c36004-b8c0-461d-9f9b-3d99dd1ed051


## Notes